### PR TITLE
Added mobile:: prefix to apps, in the hope that it'll make RiffRaff deploy correctly

### DIFF
--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -2,7 +2,7 @@
 	"packages" : {
 		"football-time-machine" : {
 			"type" : "executable-jar-webapp",
-			"apps" : [ "football-time-machine" ],
+			"apps" : [ "mobile::football-time-machine" ],
 			"data" : {
 				"port" : 18080,
 				"bucket" : "mobile-apps-api-dist",


### PR DESCRIPTION
Btw, ignore the branch name; that's a mistake
