### PR TITLE
File path slugs are now stored and retrieved case-insensitive.

### DIFF
--- a/app/common/Slugs.scala
+++ b/app/common/Slugs.scala
@@ -10,7 +10,7 @@ trait Slugs {
     slugs.map {
       case DateSlugRegex(dateSlug) => "DATE"
       case Configuration.paKey => "KEY"
-      case slug => slug
+      case slug => slug.toLowerCase
     }.mkString("/")
   }
 


### PR DESCRIPTION
This should fix breakage that depends on PA's API being case-insensitive (I'm guessing they run on Windows NT or something).
