### PR TITLE
chore: Add snyk monitoring for main branch

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,20 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    with:
+      DEBUG: true
+      ORG: guardian-mobile
+      SKIP_NODE: true
+    secrets:
+       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+


### PR DESCRIPTION
This PR reliably integrates the repository with the snyk GitHub action which will scan your code’s dependencies and alert you if vulnerabilities are found. This PR has only been raised on repos that have already been tested to make sure scanning will work out of the box. ‘reliably integrated’ means that this action compares the hash of the last commit on main to the one that snyk has, and makes sure that they match.