### PR TITLE
Update AWS S3 SDK and netty dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val archive = project
       "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
       "com.gu" %% "pa-client" % "7.0.5",
       "com.gu" %% "simple-configuration-ssm" % "1.5.6",
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.158",
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.12.311",
       "com.typesafe" % "config" % "1.3.1"
     )
   )
@@ -43,13 +43,13 @@ lazy val api = project
   .settings(
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.158",
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.12.311",
       "com.typesafe" % "config" % "1.3.1"
     )
   )
 
 lazy val download = project.settings(
-  libraryDependencies += "com.amazonaws" % "aws-java-sdk-s3" % "1.11.158"
+  libraryDependencies += "com.amazonaws" % "aws-java-sdk-s3" % "1.12.311"
 )
 
 lazy val root = project.in(file(".")).aggregate(archive, api)
@@ -59,6 +59,6 @@ lazy val root = project.in(file(".")).aggregate(archive, api)
     riffRaffPackageType := file(".nothing"),
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffArtifactResources += (assembly in api).value -> s"${(name in api).value}/${(assembly in api).value.getName}",
-    riffRaffArtifactResources += (assembly in archive).value -> s"${(name in archive).value}/${(assembly in archive).value.getName}"
+    riffRaffArtifactResources += (api / assembly).value -> s"${(api/ name ).value}/${(api / assembly).value.getName}",
+    riffRaffArtifactResources += (archive / assembly).value -> s"${(archive / name).value}/${(archive / assembly).value.getName}"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,11 @@ lazy val archive = project
       libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
       "com.gu" %% "pa-client" % "7.0.5",
-      "com.gu" %% "simple-configuration-ssm" % "1.5.6",
+      "com.gu" %% "simple-configuration-ssm" % "1.5.7",
       "com.amazonaws" % "aws-java-sdk-s3" % "1.12.311",
-      "com.typesafe" % "config" % "1.3.1"
+      "com.typesafe" % "config" % "1.3.1",
+      "io.netty" % "netty-codec-http" % "4.1.71.Final",
+      "io.netty" % "netty-common" % "4.1.77.Final"
     )
   )
 


### PR DESCRIPTION
## What does this change?
Updates the AWS S3 SDK version to fix a transitive security vulnerability in jackson databind, and at the same time make netty a direct dependency to fix a security vulnerability introduced in previous version of netty-common, netty-codec, and netty-handler.