### PR TITLE
Bump netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ def commonSettings(module: String) = List(
   assemblyJarName := s"${name.value}.jar"
 )
 
+val awsSdk2Version = "2.21.21"
+
 lazy val archive = project
   .settings(commonSettings("archive"))
   .settings(
@@ -30,12 +32,15 @@ lazy val archive = project
       libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
       "com.gu" %% "pa-client" % "7.0.5",
-        "com.gu" %% "simple-configuration-ssm" % "1.5.7",
-        "com.amazonaws" % "aws-java-sdk-s3" % "1.12.311",
-        "com.typesafe" % "config" % "1.3.1",
-        "ch.qos.logback" % "logback-classic" % "1.2.11",
-        "io.netty" % "netty-codec-http" % "4.1.100.Final",
-        "io.netty" % "netty-common" % "4.1.100.Final"
+      "com.gu" %% "simple-configuration-ssm" % "1.5.7",
+      "software.amazon.awssdk" % "autoscaling" % awsSdk2Version,
+      "software.amazon.awssdk" % "ec2" % awsSdk2Version,
+      "software.amazon.awssdk" % "ssm" % awsSdk2Version,
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.12.311",
+      "com.typesafe" % "config" % "1.3.1",
+      "ch.qos.logback" % "logback-classic" % "1.2.11",
+      "io.netty" % "netty-codec-http" % "4.1.100.Final",
+      "io.netty" % "netty-common" % "4.1.100.Final"
     )
   )
 


### PR DESCRIPTION
Snyk says we have some AWS SDK vulnerabilities introduced via Netty. By specifying a higher version of these packages we should be able to fix these vulnerabilities. 