### PR TITLE
update logback to 1.2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,3 +59,4 @@ lazy val download = project.settings(
 )
 
 lazy val root = project.in(file(".")).aggregate(archive, api)
+

--- a/build.sbt
+++ b/build.sbt
@@ -59,4 +59,3 @@ lazy val download = project.settings(
 )
 
 lazy val root = project.in(file(".")).aggregate(archive, api)
-

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val archive = project
       "software.amazon.awssdk" % "ssm" % awsSdk2Version,
       "com.amazonaws" % "aws-java-sdk-s3" % "1.12.311",
       "com.typesafe" % "config" % "1.3.1",
-      "ch.qos.logback" % "logback-classic" % "1.2.11",
+      "ch.qos.logback" % "logback-classic" % "1.2.13",
       "io.netty" % "netty-codec-http" % "4.1.100.Final",
       "io.netty" % "netty-common" % "4.1.100.Final"
     )


### PR DESCRIPTION
Update logback to ch.qos.logback:logback-classic@1.2.13 in order to fix snyk vulnerability https://www.cve.org/CVERecord?id=CVE-2023-6378

