### PR TITLE
Add cloudformation step to riff raff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
               - archive/target/scala-2.12/football-time-machine-archive.jar
             football-time-machine-api:
               - api/target/scala-2.12/football-time-machine-api.jar
-            cfn-football-time-machine:
+            football-time-machine:
               - cfn.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,5 @@ jobs:
               - archive/target/scala-2.12/football-time-machine-archive.jar
             football-time-machine-api:
               - api/target/scala-2.12/football-time-machine-api.jar
+            cfn-football-time-machine:
+              - cfn.yaml

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,10 +2,12 @@ stacks: [mobile]
 regions: [eu-west-1]
 
 deployments:
-  cfn-football-time-machine:
+  football-time-machine:
     type: cloud-formation
     parameters:
       templatePath: cfn.yaml
+      prependStackToCloudFormationStackName: false
+      appendStageToCloudFormationStackName: true
   football-time-machine-archive:
     type: aws-lambda
     parameters:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,6 +2,10 @@ stacks: [mobile]
 regions: [eu-west-1]
 
 deployments:
+  cfn-football-time-machine:
+    type: cloud-formation
+    parameters:
+      templatePath: cfn.yaml
   football-time-machine-archive:
     type: aws-lambda
     parameters:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a step to the riff raff deployment to include updates to the cloudformation, so that we can use riff raff to upload changes to that file 
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
