### PR TITLE
Automate approval and merging of Scala Steward PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Build and Test
 on:
   push:
     branches:
-      - '*'
+      - main
   pull_request:
     branches:
-      - '*'
+      - main
 
 jobs:
   scala_steward:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    types: [opened, reopened]
 
 jobs:
   scala_steward:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,43 @@ on:
       - main
 
 jobs:
+  scala_steward:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.actor == 'gu-scala-steward-public-repos[bot]'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Check if PR has 'minor' or 'patch' label
+        id: check_labels
+        run: |
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_NUMBER=$(echo $PR_URL | awk -F/ '{print $NF}')
+          LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
+          if [[ "$LABELS" != *"minor"* && "$LABELS" != *"patch"* ]]; then
+            echo "PR does not have 'minor' or 'patch' label. Skipping approval and merge."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve a PR
+        if: steps.check_labels.outputs.result == 'success'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Scala Steward PRs
+        if: steps.check_labels.outputs.result == 'success'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - '*'
   pull_request:
-    types: [opened, reopened]
+    branches:
+      - '*'
 
 jobs:
   scala_steward:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on:
   push:
     branches:
-      - main
+      - '*'
   pull_request:
     types: [opened, reopened]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,6 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for Scala Steward PRs
-        if: steps.check_labels.outputs.result == 'success'
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/scala-steward.conf
+++ b/.github/workflows/scala-steward.conf
@@ -1,0 +1,24 @@
+# Original template https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+
+# pullRequests.frequency allows to control how often or when Scala Steward
+# is allowed to create pull requests.
+pullRequests.frequency = "7 days"
+
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+
+pullRequests.grouping = [
+  { name = "major", "title" = "Major updates", "filter" = [{"version" = "major"}, "customLabels" = ["major"] },
+  { name = "minor", "title" = "Minor updates", "filter" = [{"version" = "minor"}, "customLabels" = ["minor"] },
+  { name = "patch", "title" = "Patch updates", "filter" = [{"version" = "patch"}, "customLabels" = ["patch"] },
+  { name = "all", "title" = "Other dependency updates", "filter" = [{"group" = "*"}] }
+]
+
+# pullRequests.customLabels allows to add custom labels to PRs.
+# This is useful if you want to use the labels for automation (project board for example).
+# Defaults to no labels (no labels are added).
+pullRequests.customLabels = [ "dependencies" ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Set custom rules in `scala-steward.conf` to add `major`, `minor`, and `patch` labels to scala-steward PRs
- Add a step in Github Action so that if a scala-steward PR is a `minor` or `patch` update (i.e. not a `major` update which probably should have a human review), then auto-approve and merge them

If successful, we can expand this to other repos, which would make it much easier for us to maintain them.
