### PR TITLE
Update scala-steward.conf

### DIFF
--- a/.github/workflows/scala-steward.conf
+++ b/.github/workflows/scala-steward.conf
@@ -22,7 +22,7 @@ pullRequests.grouping = [
 # This is useful if you want to use the labels for automation (project board for example).
 # Defaults to no labels (no labels are added).
 pullRequests.customLabels = [ 
-  { name = "patches", labels = ["patch"]},
+  { name = "patch", labels = ["patch"]},
   { name = "minor", labels = ["minor"]},
   { name = "major", labels = ["major"]},
   { name = "all", labels = ["dependencies"]}

--- a/.github/workflows/scala-steward.conf
+++ b/.github/workflows/scala-steward.conf
@@ -12,13 +12,18 @@ pullRequests.frequency = "7 days"
 # the default procedure (one PR per update).
 
 pullRequests.grouping = [
-  { name = "major", "title" = "Major updates", "filter" = [{"version" = "major"}, "customLabels" = ["major"] },
-  { name = "minor", "title" = "Minor updates", "filter" = [{"version" = "minor"}, "customLabels" = ["minor"] },
-  { name = "patch", "title" = "Patch updates", "filter" = [{"version" = "patch"}, "customLabels" = ["patch"] },
+    { name = "patch", "title" = "Patch updates", "filter" = [{"version" = "patch"}},
+  { name = "minor", "title" = "Minor updates", "filter" = [{"version" = "minor"}},
+  { name = "major", "title" = "Major updates", "filter" = [{"version" = "major"}},
   { name = "all", "title" = "Other dependency updates", "filter" = [{"group" = "*"}] }
 ]
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).
 # Defaults to no labels (no labels are added).
-pullRequests.customLabels = [ "dependencies" ]
+pullRequests.customLabels = [ 
+  { name = "patches", labels = ["patch"]},
+  { name = "minor", labels = ["minor"]},
+  { name = "major", labels = ["major"]},
+  { name = "all", labels = ["dependencies"]}
+]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Unfortunately creating the `.scala-steward.conf` file in #44 did not add the desired labels (e.g. 'minor', 'patch') to the PRs, which meant CI could not pick up the relevant PRs to enable auto approvals. So trying a different configuration to see if this works 🤞
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
