### PR TITLE
Override jackson version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ def commonSettings(module: String) = List(
 
 val awsSdk2Version = "2.26.25"
 
+val jacksonOverride =  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0-rc1"
+
 lazy val archive = project
   .settings(commonSettings("archive"))
   .settings(
@@ -40,11 +42,10 @@ lazy val archive = project
       "com.typesafe" % "config" % "1.4.3",
       "ch.qos.logback" % "logback-classic" % "1.5.6",
       "io.netty" % "netty-codec-http" % "4.1.112.Final",
-      "io.netty" % "netty-common" % "4.1.112.Final"
+      "io.netty" % "netty-common" % "4.1.112.Final",
+      jacksonOverride
     )
   )
-
-val jacksonOverride =  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0-rc1"
 
 lazy val api = project
   .settings(commonSettings("api"))
@@ -52,7 +53,8 @@ lazy val api = project
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
       "com.amazonaws" % "aws-java-sdk-s3" % "1.12.307",
-      "com.typesafe" % "config" % "1.4.3"
+      "com.typesafe" % "config" % "1.4.3",
+      jacksonOverride
     )
   )
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Override `jackson-core` to a version identified by Snyk to resolve vulnerabilities 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
