### PR TITLE
Fix jackson vuln

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ def commonSettings(module: String) = List(
 
 val awsSdk2Version = "2.29.52"
 
-val jacksonOverride =  "com.fasterxml.jackson.core" % "jackson-core" % "2.18.2"
+val jacksonCore =  "com.fasterxml.jackson.core" % "jackson-core" % "2.18.2"
+val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.2"
 
 lazy val archive = project
   .settings(commonSettings("archive"))
@@ -43,7 +44,8 @@ lazy val archive = project
       "ch.qos.logback" % "logback-classic" % "1.5.16",
       "io.netty" % "netty-codec-http" % "4.1.117.Final",
       "io.netty" % "netty-common" % "4.1.117.Final",
-      jacksonOverride
+      jacksonCore,
+      jacksonDatabind
     )
   )
 
@@ -54,14 +56,16 @@ lazy val api = project
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
       "com.amazonaws" % "aws-java-sdk-s3" % "1.12.307",
       "com.typesafe" % "config" % "1.4.3",
-      jacksonOverride
+      jacksonCore,
+      jacksonDatabind
     )
   )
 
 lazy val download = project.settings(
   libraryDependencies ++= Seq(
-    "com.amazonaws" % "aws-java-sdk-s3" % "1.12.307", 
-    jacksonOverride
+    "com.amazonaws" % "aws-java-sdk-s3" % "1.12.307",
+    jacksonCore,
+    jacksonDatabind
   )
 )
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds an explicit library dependency of jackson-databind to address this issue raised in dependabot: https://github.com/guardian/football-time-machine/security/dependabot/1 and https://github.com/guardian/football-time-machine/security/dependabot/2

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
