### PR TITLE
Use v2 for s3 lib

### DIFF
--- a/api/src/main/scala/com/gu/footballtimemachine/ApiLambda.scala
+++ b/api/src/main/scala/com/gu/footballtimemachine/ApiLambda.scala
@@ -82,10 +82,6 @@ object ApiLambda {
 
     val versions = s3Client.listObjectVersions(ListObjectVersionsRequest.builder().bucket(bucket).prefix(s3Path).build()).versions().asScala.toList.sortBy(_.lastModified)
 
-    println(currentTime)
-
-    println(versions.find(v => v.lastModified().toEpochMilli() > currentTime).map(_.lastModified().toEpochMilli))
-
     val version = versions.find(v => v.lastModified().toEpochMilli() > currentTime).getOrElse(versions.last).versionId
 
     val gor = GetObjectRequest.builder.bucket(bucket).key(s3Path).versionId(version).build()

--- a/archive/src/main/scala/com/gu/footballtimemachine/Configuration.scala
+++ b/archive/src/main/scala/com/gu/footballtimemachine/Configuration.scala
@@ -1,28 +1,23 @@
 package com.gu.footballtimemachine
 
-import com.amazonaws.auth.{ AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain }
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.{ AmazonS3, AmazonS3ClientBuilder }
-import com.gu.{ AppIdentity, AwsIdentity, DevIdentity }
-import com.gu.conf.{ ConfigurationLoader, SSMConfigurationLocation }
+import com.gu.{AppIdentity, AwsIdentity}
+import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 import com.typesafe.config.Config
-import software.amazon.awssdk.auth.credentials.{ AwsCredentialsProviderChain => AwsCredentialsProviderChainV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2 }
+import software.amazon.awssdk.auth.credentials.{ProfileCredentialsProvider, AwsCredentialsProviderChain => AwsCredentialsProviderChainV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 class Configuration {
-  val credentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("mobile"),
-    DefaultAWSCredentialsProviderChain.getInstance())
 
   val credentialsv2: AwsCredentialsProviderChainV2 = AwsCredentialsProviderChainV2.of(
     ProfileCredentialsProviderV2.builder.profileName("mobile").build,
     DefaultCredentialsProviderV2.create)
 
-  val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard()
-    .withCredentials(credentials)
-    .withRegion(Regions.EU_WEST_1)
+  val s3Client = S3Client.builder()
+    .credentialsProvider(credentialsv2)
+    .region(Region.EU_WEST_1)
     .build()
 
   val stack: String = Option(System.getenv("Stack")).getOrElse("mobile")

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val api = project
   .settings(
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.12.307",
+      "software.amazon.awssdk" % "s3" % awsSdk2Version,
       "com.typesafe" % "config" % "1.4.3",
       jacksonCore,
       jacksonDatabind
@@ -63,7 +63,7 @@ lazy val api = project
 
 lazy val download = project.settings(
   libraryDependencies ++= Seq(
-    "com.amazonaws" % "aws-java-sdk-s3" % "1.12.307",
+    "software.amazon.awssdk" % "s3" % awsSdk2Version,
     jacksonCore,
     jacksonDatabind
   )

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val archive = project
       "software.amazon.awssdk" % "autoscaling" % awsSdk2Version,
       "software.amazon.awssdk" % "ec2" % awsSdk2Version,
       "software.amazon.awssdk" % "ssm" % awsSdk2Version,
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.12.781",
+      "software.amazon.awssdk" % "s3" % awsSdk2Version,
       "com.typesafe" % "config" % "1.4.3",
       "ch.qos.logback" % "logback-classic" % "1.5.17",
       "io.netty" % "netty-codec-http" % "4.1.119.Final",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This upgrades the version of the amazon s3 for the v2 version. 

We have a vulnerability notification for the software.amazon.ion:ion-java

![ion-vuln](https://github.com/user-attachments/assets/1cc56012-07d7-41cf-9482-2f00a09fe91b)

Looking at the dependency graph: 
![ion](https://github.com/user-attachments/assets/291a7611-6f4b-4025-8306-9a6798d0d318)
This library is dependent on a package which comes from the version one of s3:

![s3-v1](https://github.com/user-attachments/assets/319f7700-1db5-4d1b-927d-30db608eb4da)


By upgrading this we no longer need to dependent on this library that has the vulnerability associated with it

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
