### PR TITLE
Fix AWS credentials provider chain

### DIFF
--- a/api/src/main/scala/com/gu/footballtimemachine/ApiLambda.scala
+++ b/api/src/main/scala/com/gu/footballtimemachine/ApiLambda.scala
@@ -4,10 +4,9 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import java.time.format.DateTimeFormatter
 import java.time.{ Instant, ZoneId, ZonedDateTime }
-import software.amazon.awssdk.auth.credentials.{ AwsCredentialsProviderChain, InstanceProfileCredentialsProvider, ProfileCredentialsProvider }
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.s3.S3ClientBuilder
 import software.amazon.awssdk.services.s3.model.{ GetObjectRequest, ListObjectVersionsRequest, PutObjectRequest }
 
 import java.nio.charset.StandardCharsets
@@ -59,9 +58,10 @@ class ApiGatewayRequestContext {
 
 object ApiLambda {
 
-  val credentials = AwsCredentialsProviderChain.builder().credentialsProviders(
-    ProfileCredentialsProvider.create("mobile"),
-    InstanceProfileCredentialsProvider.create()).build()
+  val credentials = DefaultCredentialsProvider
+    .builder
+    .profileName("mobile")
+    .build
 
   val s3Client = S3Client.builder()
     .credentialsProvider(credentials)


### PR DESCRIPTION
Currently these Lambdas are failing in `CODE` with errors such as:

`software.amazon.awssdk.core.exception.SdkClientException software.amazon.awssdk.core.exception.SdkClientException: Unable to load credentials from any of the providers in the chain`

This PR fixes the credentials provider chain[^1].

I've confirmed that this still works when running locally and have also [deployed](https://riffraff.gutools.co.uk/deployment/view/57d76918-b679-41dd-95ef-e784ce695703) and tested in `CODE`.

[^1]: I think this might have been broken since https://github.com/guardian/football-time-machine/pull/106, which swapped to using a `InstanceProfileCredentialsProvider`. IIUC this will only work correctly when running in EC2.